### PR TITLE
Picture component : added support for browser-side duplication

### DIFF
--- a/src/Component/Form/Picture.php
+++ b/src/Component/Form/Picture.php
@@ -26,7 +26,6 @@ class Picture extends \Sy\Component\Html\Form\Element {
 			'ICON'  => isset($this->options['icon'])  ? $this->options['icon']            : 'camera',
 			'LABEL' => isset($this->options['label']) ? $this->_($this->options['label']) : '',
 			'TITLE' => isset($this->options['title']) ? $this->_($this->options['title']) : '',
-			'PICTURE_ID' => uniqid('picture'),
 		]);
 
 		$js = new \Sy\Component\WebComponent();

--- a/src/Component/Form/Picture.tpl
+++ b/src/Component/Form/Picture.tpl
@@ -1,5 +1,5 @@
 <input class="picture-input-hidden" type="hidden" name="{NAME}" />
 <button class="btn btn-{COLOR} btn-{SIZE} {CLASS}" onclick="$(this).siblings('input.picture-input-file').click();return false" title="{TITLE}" data-title="{TITLE}" data-trigger="hover" data-container="body"><span class="fas fa-{ICON}"></span> {LABEL}</button>
-<input id="{PICTURE_ID}" type="file" class="picture-input-file d-none" onclick="this.value=null" accept="image/*" multiple data-caption-placeholder="{'Add a caption'}" />
+<input type="file" class="picture-input-file d-none" onclick="this.value=null" accept="image/*" multiple data-caption-placeholder="{'Add a caption'}" />
 <div class="loader text-center" style="display:none"><i class="fas fa-circle-notch fa-spin"></i></div>
 <div class="picture-div text-center"></div>


### PR DESCRIPTION
Pour rendre ça possible, j'ai :

1) supprimé la notion de "id unique de l'instance" : 
              - généré par le PHP avec uniqid()
              - transféré via le template
              - utilisé pour se repérer dans le tableau global SyFormPicture.pictures (que j'ai supprimé aussi, du coup, pour le remplacer par un tableau par champ hidden)

2) regroupé les bind d'event handler dans une fonction que je peux rappeler à loisir
